### PR TITLE
Add recent transactions view for cashiers

### DIFF
--- a/src/components/ui/Header.jsx
+++ b/src/components/ui/Header.jsx
@@ -24,6 +24,13 @@ const Header = ({ user, onLogout }) => {
       tooltip: 'Payment Processing & Checkout'
     },
     {
+      label: 'Transactions',
+      path: '/cashier-recent-transactions',
+      icon: 'History',
+      roles: ['cashier', 'manager'],
+      tooltip: 'Recent Transactions'
+    },
+    {
       label: 'Dashboard',
       path: '/admin-sales-dashboard-and-analytics',
       icon: 'BarChart3',

--- a/src/components/ui/Sidebar.jsx
+++ b/src/components/ui/Sidebar.jsx
@@ -30,6 +30,13 @@ const Sidebar = ({ user, isCollapsed = false, onToggleCollapse, onLogout }) => {
           icon: 'CreditCard',
           roles: ['cashier', 'manager'],
           description: 'Handle payments & checkout'
+        },
+        {
+          label: 'Recent Transactions',
+          path: '/cashier-recent-transactions',
+          icon: 'History',
+          roles: ['cashier', 'manager'],
+          description: 'View recent transactions'
         }
       ]
     },

--- a/src/pages/admin-sales-dashboard-and-analytics/components/TransactionFeed.jsx
+++ b/src/pages/admin-sales-dashboard-and-analytics/components/TransactionFeed.jsx
@@ -3,11 +3,12 @@ import { format, parseISO } from 'date-fns';
 import Icon from '../../../components/AppIcon';
 import Button from '../../../components/ui/Button';
 
-const TransactionFeed = ({ 
+const TransactionFeed = ({
   apiEndpoint = '/api/transactions',
   websocketUrl = 'ws://localhost:8080/transactions',
   pollInterval = 30000, // 30 seconds fallback polling
-  pageSize = 50 
+  pageSize = 50,
+  showActions = true
 }) => {
   const [transactions, setTransactions] = useState([]);
   const [isLive, setIsLive] = useState(true);
@@ -375,26 +376,28 @@ const TransactionFeed = ({
                     KES {transaction?.amount?.toLocaleString('en-KE', { minimumFractionDigits: 2 })}
                   </div>
                   
-                  <div className="flex space-x-1">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      iconName="Eye"
-                      iconSize={12}
-                      className="touch-feedback p-1"
-                      title="View details"
-                      onClick={() => alert(`Viewing transaction ${transaction?.id}`)}
-                    />
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      iconName="Receipt"
-                      iconSize={12}
-                      className="touch-feedback p-1"
-                      title="View receipt"
-                      onClick={() => alert(`Opening receipt for ${transaction?.id}`)}
-                    />
-                  </div>
+                  {showActions && (
+                    <div className="flex space-x-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        iconName="Eye"
+                        iconSize={12}
+                        className="touch-feedback p-1"
+                        title="View details"
+                        onClick={() => alert(`Viewing transaction ${transaction?.id}`)}
+                      />
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        iconName="Receipt"
+                        iconSize={12}
+                        className="touch-feedback p-1"
+                        title="View receipt"
+                        onClick={() => alert(`Opening receipt for ${transaction?.id}`)}
+                      />
+                    </div>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/pages/cashier-recent-transactions/index.jsx
+++ b/src/pages/cashier-recent-transactions/index.jsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Header from '../../components/ui/Header';
+import TransactionFeed from '../admin-sales-dashboard-and-analytics/components/TransactionFeed';
+
+const CashierRecentTransactions = () => {
+  const navigate = useNavigate();
+  const [user] = useState({
+    id: 'CSH001',
+    name: 'Sarah Wanjiku',
+    email: 'sarah.wanjiku@bobacafe.co.ke',
+    role: 'cashier'
+  });
+
+  const handleLogout = () => {
+    navigate('/staff-login-and-authentication');
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header user={user} onLogout={handleLogout} />
+      <div className="pt-16 p-4 max-w-4xl mx-auto">
+        <h1 className="text-2xl font-bold text-foreground mb-4">Recent Transactions</h1>
+        <p className="text-sm text-muted-foreground mb-4">
+          View recent transactions. These records are read-only.
+        </p>
+        <TransactionFeed showActions={false} />
+      </div>
+    </div>
+  );
+};
+
+export default CashierRecentTransactions;

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -10,6 +10,7 @@ import StaffLoginAndAuthentication from './pages/staff-login-and-authentication/
 import PaymentProcessingAndCheckout from './pages/payment-processing-and-checkout/index.jsx';
 import PointOfSaleOrderProcessing from './pages/point-of-sale-order-processing/index.jsx';
 import AdminSalesDashboardAndAnalytics from './pages/admin-sales-dashboard-and-analytics/index.jsx';
+import CashierRecentTransactions from './pages/cashier-recent-transactions/index.jsx';
 
 // Create placeholder components for missing pages
 const Dashboard = () => (
@@ -220,6 +221,7 @@ const Routes = () => {
           <Route path="/staff-login-and-authentication" element={<StaffLoginAndAuthentication />} />
           <Route path="/payment-processing-and-checkout" element={<PaymentProcessingAndCheckout />} />
           <Route path="/admin-sales-dashboard-and-analytics" element={<AdminSalesDashboardAndAnalytics />} />
+          <Route path="/cashier-recent-transactions" element={<CashierRecentTransactions />} />
           
           {/* Additional placeholder routes */}
           <Route path="/dashboard" element={<Dashboard />} />


### PR DESCRIPTION
## Summary
- add cashier recent transactions page
- wire recent transactions route and navigation
- make transaction feed actions optional to keep cashier view read-only

## Testing
- `npm test` *(fails: Missing script 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68a2fa9139588330a58a88eadf695080